### PR TITLE
Remove BOM symbol

### DIFF
--- a/messages/ru/kvdatetime.php
+++ b/messages/ru/kvdatetime.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Message translations.
  *


### PR DESCRIPTION
File with russian messages contained BOM symbol.
I just removed it via command
```
awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1' kvdatetime.php > kvdatetime2.php
mv kvdatetime2.php kvdatetime.php
```

Here is the diff
```
diff --git a/messages/ru/kvdatetime.php b/messages/ru/kvdatetime.php
index 9da5918..c6bf0c3 100644
--- a/messages/ru/kvdatetime.php
+++ b/messages/ru/kvdatetime.php
@@ -1,4 +1,4 @@
-<U+FEFF><?php
+<?php
 /**
  * Message translations.
  *

```