### PR TITLE
Update bootstrap-datetimepicker.js

### DIFF
--- a/assets/js/bootstrap-datetimepicker.js
+++ b/assets/js/bootstrap-datetimepicker.js
@@ -109,7 +109,7 @@
     this.initialDate = options.initialDate || new Date();
     this.zIndex = options.zIndex || this.element.data('z-index') || undefined;
     this.title = typeof options.title === 'undefined' ? false : options.title;
-    this.defaultTimeZone = (new Date).toString().split('(')[1].slice(0, -1);
+    this.defaultTimeZone = (new Date).toString().split('GMT')[1].slice(0,3);
     this.timezone = options.timezone || this.defaultTimeZone;
 
     this.icons = {


### PR DESCRIPTION
TypeError: (intermediate value).toString(...).split(...)[1] is undefined
This error in  firefox

replace
this.defaultTimeZone = (new Date).toString().split('(')[1].slice(0, -1);
to
this.defaultTimeZone = (new Date).toString().split('GMT')[1].slice(0,3);
