### PR TITLE
Update German Locale

### DIFF
--- a/assets/js/locales/bootstrap-datetimepicker.de.js
+++ b/assets/js/locales/bootstrap-datetimepicker.de.js
@@ -13,6 +13,6 @@
 		suffix: [],
 		meridiem: [],
 		weekStart: 1,
-		format: "dd.mm.yyyy"
+		format: "dd.mm.yyyy HH:ii"
 	};
 }(jQuery));


### PR DESCRIPTION
As we are here in a DateTime Picker, it should show time as default.

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-widget-datetimepicker/blob/master/CHANGE.md)):

- Updated default format for locale de, to show the time as default

## Related Issues
#79 